### PR TITLE
Bump our protocol version to 1.4.1

### DIFF
--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -702,7 +702,7 @@ class ElectrumX(SessionBase):
     '''A TCP server that handles incoming Electrum connections.'''
 
     PROTOCOL_MIN = (1, 2)
-    PROTOCOL_MAX = (1, 4)
+    PROTOCOL_MAX = (1, 4, 1)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
I forgot to pull this in from ElectrumX. Oops!  We have all the methods for this protocol so we're good. I literally just didn't include the change that bumped protocol version.

This new minor version is only for AuxPoW based coins such as ViaCoin, Emercoin, etc.. so it's not a big deal.
