### PR TITLE
Version 1.10.1 (21 April 2019)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,19 @@
    we feel is too restrictive for normal BCH usage of the server.
 
 
+Version 1.10.1 (21 April 2019)
+==============================
+
+* Added PEER_DISCOVERY_TOR environment variable (default off). If on, then
+  ElectronX will behave as before this version and always forward/discover
+  *.onion peers.  If off, then it will completely ignore *.onion peers and
+  never forward them.  This policy change has been implemented because of the
+  ease with which sybil attacks are possible if PEER_DISCOVER_TOR is enabled.
+  (cculianu)
+* Added more stuff to `getenv` rpc command display (cculinau)
+* Optimized the ban handling a little bit to refuse peers earlier in the
+  lifecycle of peer_discovery if a host is banned. (cculianu)
+
 Version 1.10.0 (14 April 2019)
 ==============================
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,13 +15,13 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
-VERSION="ElectronX 1.10.0"
+VERSION="ElectronX 1.10.1"
 
 # -- Project information -----------------------------------------------------
 
 project = 'ElectronX'
-copyright = '2016-2018, Neil Booth'
-author = 'Neil Booth'
+copyright = '2016-2018, Neil Booth; 2019, Electron Cash LLC'
+author = 'Neil Booth & Electron Cash LLC'
 
 # The full version including branding
 release = VERSION

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -378,6 +378,20 @@ some of this.
   discovery is disabled and the server will only return itself in the
   peers list.
 
+.. envvar:: PEER_DISCOVERY_TOR
+
+  This environment variable is case-insensitive and defaults to
+  ``off`` (or ``0``).  It is identical to PEER_DISCOVERY except it affects
+  *.onion peers only.
+
+  The default is ``off`` because of the sybil attack vector this represents.
+
+  If ``on``, then ElectrumX will accept peers with *.onion hostnames and attempt
+  to verify them, and forward its discoveries to its peers.
+
+  If ``off`` (the default), then ElectrumX will never discover or announce any
+  *.onion peers, and will pretend they simply do not exist.
+
 .. envvar:: PEER_ANNOUNCE
 
   Set this environment variable to empty to disable announcing itself.

--- a/electrumx/__init__.py
+++ b/electrumx/__init__.py
@@ -1,4 +1,4 @@
-version = 'ElectronX 1.10.0'
+version = 'ElectronX 1.10.1'
 version_short = version.split()[-1]
 
 from electrumx.server.controller import Controller

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -691,17 +691,7 @@ class SessionManager(object):
 
     async def rpc_getenv(self):
         '''Return all the env vars used to configure the server. '''
-        env = {}
-        for name in dir(self.env).copy():
-            if name.startswith('_'):
-                continue
-            value = getattr(self.env, name, None)
-            if not isinstance(value, (str, int, float, bool)):
-                continue
-            if isinstance(value, bool):
-                value = "1" if value else ""  # Map bools to non-empty/empty strings to match how they are parsed
-            env[name.upper()] = value
-        return env
+        return self.env.get_info()
 
     async def rpc_groups(self):
         '''Return statistics about the session groups.'''

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import setuptools
-version = '1.10.0'
+version = '1.10.1'
 
 setuptools.setup(
     name='electronX',


### PR DESCRIPTION
* Added PEER_DISCOVERY_TOR environment variable (default off). If on, then
  ElectronX will behave as before this version and always forward/discover
  *.onion peers.  If off, then it will completely ignore *.onion peers and
  never forward them.  This policy change has been implemented because of the
  ease with which sybil attacks are possible if PEER_DISCOVER_TOR is enabled.
  (cculianu)
* Added more stuff to `getenv` rpc command display (cculinau)
* Optimized the ban handling a little bit to refuse peers earlier in the
  lifecycle of peer_discovery if a host is banned. (cculianu)