### PR TITLE
Reduce memory spikes

### DIFF
--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -103,7 +103,7 @@ class Prefetcher(object):
                 # some chains can be lumpy.
                 cache_room = max(self.min_cache_size // self.ave_size, 1)
                 count = min(daemon_height - self.fetched_height, cache_room)
-                count = min(100, max(count, 0))
+                count = min(10, max(count, 0))
                 if not count:
                     self.caught_up = True
                     return False


### PR DESCRIPTION
On testnet we see some massive blocks around the 1300000 level, which cause
HUGE memory spikes in electrumx when prefetching blocks. This fixes it
but I'm not sure how badly it hurts performance...